### PR TITLE
remove additional checks for vcruntime

### DIFF
--- a/terraform.tfvars.json
+++ b/terraform.tfvars.json
@@ -635,13 +635,7 @@
     },
     {
       "name": "vcruntime",
-      "repo_type": "cookbook",
-      "additional_status_checks": [
-        "integration (windows-2019, vc11)",
-        "integration (windows-2019, vc12)",
-        "integration-windows-2016 (windows-2016, vc11)",
-        "integration-windows-2016 (windows-2016, vc12)",
-        "integration-windows-2016 (windows-2016, vc14)"
+      "repo_type": "cookbook"
       ]
     },
     {


### PR DESCRIPTION
Platform 2016 is no longer supported in Github actions, remaining tests are managed in the ci.yml file